### PR TITLE
Do not exit gdb when ptrfind fails parsing arguments

### DIFF
--- a/ptrfind.py
+++ b/ptrfind.py
@@ -106,7 +106,8 @@ class PtrFind (gdb.Command):
     args = None
     try:
       args = parser.parse_args(gdb.string_to_argv(arg))
-    except Exception:
+    # BaseException also catches the SystemExit raised by argparse on error
+    except BaseException as e:
       PtrFind.print_error(f"Option parsing failed")
       return
     


### PR DESCRIPTION
argparse.ArgumentParser exits the program on error by default by raising SystemExit, leading gdb to exit. In Python 3.9, the option exit_on_error was introduced. However, using this would complicate compatibility with older version. Instead, I would suggest to catch the SystemExit exception raised by parse_args.